### PR TITLE
#1/user signup, login, logout, refresh-token reissue feature

### DIFF
--- a/src/main/java/com/sparta/kanbanboardproject/domain/auth/controller/AuthController.java
+++ b/src/main/java/com/sparta/kanbanboardproject/domain/auth/controller/AuthController.java
@@ -1,4 +1,23 @@
 package com.sparta.kanbanboardproject.domain.auth.controller;
 
+import com.sparta.kanbanboardproject.domain.auth.service.AuthService;
+import com.sparta.kanbanboardproject.global.security.UserDetailsImpl;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.AllArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@AllArgsConstructor
+@Slf4j(topic = "AuthController")
 public class AuthController {
+
+    private final AuthService authService;
+    @PostMapping("/auth/refresh-token")
+    public void refreshToken(HttpServletRequest request, HttpServletResponse response) {
+        authService.refreshToken(request, response);
+    }
 }

--- a/src/main/java/com/sparta/kanbanboardproject/domain/auth/controller/AuthController.java
+++ b/src/main/java/com/sparta/kanbanboardproject/domain/auth/controller/AuthController.java
@@ -17,8 +17,12 @@ public class AuthController {
 
     private final AuthService authService;
     @PostMapping("/auth/refresh-token")
-    public ResponseEntity<String> refreshToken(HttpServletRequest request, HttpServletResponse response) {
+    public ResponseEntity<String> refreshToken(
+            HttpServletRequest request,
+            HttpServletResponse response) {
+
         authService.refreshToken(request, response);
+
         return ResponseEntity.status(HttpStatus.OK)
                 .body("access와 refresh 토큰을 재발급했습니다.");
     }

--- a/src/main/java/com/sparta/kanbanboardproject/domain/auth/controller/AuthController.java
+++ b/src/main/java/com/sparta/kanbanboardproject/domain/auth/controller/AuthController.java
@@ -1,12 +1,12 @@
 package com.sparta.kanbanboardproject.domain.auth.controller;
 
 import com.sparta.kanbanboardproject.domain.auth.service.AuthService;
-import com.sparta.kanbanboardproject.global.security.UserDetailsImpl;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.AllArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -17,7 +17,9 @@ public class AuthController {
 
     private final AuthService authService;
     @PostMapping("/auth/refresh-token")
-    public void refreshToken(HttpServletRequest request, HttpServletResponse response) {
+    public ResponseEntity<String> refreshToken(HttpServletRequest request, HttpServletResponse response) {
         authService.refreshToken(request, response);
+        return ResponseEntity.status(HttpStatus.OK)
+                .body("access와 refresh 토큰을 재발급했습니다.");
     }
 }

--- a/src/main/java/com/sparta/kanbanboardproject/domain/auth/service/AuthService.java
+++ b/src/main/java/com/sparta/kanbanboardproject/domain/auth/service/AuthService.java
@@ -33,7 +33,7 @@ public class AuthService {
         }
 
         // refreshToken 유효성 확인
-        if(jwtService.validateToken(refreshToken)){
+        if (jwtService.validateToken(refreshToken)) {
 
             // accessToken 새로 발급
             String newAccessToken = jwtService.createToken(username);

--- a/src/main/java/com/sparta/kanbanboardproject/domain/auth/service/AuthService.java
+++ b/src/main/java/com/sparta/kanbanboardproject/domain/auth/service/AuthService.java
@@ -22,21 +22,27 @@ public class AuthService {
 
         String refreshToken = request.getHeader("RefreshToken").substring(7);
 
-        User getUser = userRepository.findByRefreshToken(request.getHeader("RefreshToken")).orElseThrow(
+        String username = jwtService.extractUsername(refreshToken);
+
+        User getUser = userRepository.findByUsername(username).orElseThrow(
                 () -> new IllegalArgumentException("유저를 찾을 수 없습니다.")
         );
+
+        if (!refreshToken.equals(getUser.getRefreshToken().substring(7))) {
+            throw new IllegalArgumentException("refreshToken이 유효하지 않습니다.");
+        }
 
         // refreshToken 유효성 확인
         if(jwtService.validateToken(refreshToken)){
 
             // accessToken 새로 발급
-            String newAccessToken = jwtService.createToken(getUser.getUsername());
+            String newAccessToken = jwtService.createToken(username);
             log.info("새로운 access token : {}", newAccessToken);
             //refreshToken 새로 발급
-            String newRefreshToken = jwtService.createRefreshToken(getUser.getUsername());
+            String newRefreshToken = jwtService.createRefreshToken(username);
             log.info("새로운 refresh token : {}", newRefreshToken);
 
-            User saveUser = userRepository.findByUsername(getUser.getUsername()).orElseThrow(IllegalArgumentException::new);
+            User saveUser = userRepository.findByUsername(username).orElseThrow(IllegalArgumentException::new);
             saveUser.setRefreshToken(newRefreshToken);
             userRepository.save(saveUser);
 

--- a/src/main/java/com/sparta/kanbanboardproject/domain/auth/service/AuthService.java
+++ b/src/main/java/com/sparta/kanbanboardproject/domain/auth/service/AuthService.java
@@ -1,4 +1,47 @@
 package com.sparta.kanbanboardproject.domain.auth.service;
 
+import com.sparta.kanbanboardproject.domain.user.entity.User;
+import com.sparta.kanbanboardproject.domain.user.repository.UserRepository;
+import com.sparta.kanbanboardproject.global.jwt.JwtService;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+@Slf4j(topic = "TokenService")
+@Component
 public class AuthService {
+    private final UserRepository userRepository;
+    private final JwtService jwtService;
+
+    public void refreshToken(HttpServletRequest request, HttpServletResponse response) {
+
+        String refreshToken = request.getHeader("RefreshToken").substring(7);
+
+        User getUser = userRepository.findByRefreshToken(request.getHeader("RefreshToken")).orElseThrow(
+                () -> new IllegalArgumentException("유저를 찾을 수 없습니다.")
+        );
+
+        // refreshToken 유효성 확인
+        if(jwtService.validateToken(refreshToken)){
+
+            // accessToken 새로 발급
+            String newAccessToken = jwtService.createToken(getUser.getUsername());
+            log.info("새로운 access token : {}", newAccessToken);
+            //refreshToken 새로 발급
+            String newRefreshToken = jwtService.createRefreshToken(getUser.getUsername());
+            log.info("새로운 refresh token : {}", newRefreshToken);
+
+            User saveUser = userRepository.findByUsername(getUser.getUsername()).orElseThrow(IllegalArgumentException::new);
+            saveUser.setRefreshToken(newRefreshToken);
+            userRepository.save(saveUser);
+
+            response.setHeader("Authorization", newAccessToken);
+            response.setHeader("RefreshToken", newRefreshToken);
+        }
+    }
 }

--- a/src/main/java/com/sparta/kanbanboardproject/domain/user/controller/UserController.java
+++ b/src/main/java/com/sparta/kanbanboardproject/domain/user/controller/UserController.java
@@ -22,21 +22,19 @@ public class UserController {
     private final UserService userService;
 
     @PostMapping("/users/signup")
-    public ResponseEntity<String> signUp(
-            @Valid @RequestBody SignupRequestDto requestDto) {
+    public ResponseEntity<String> signUp(@Valid @RequestBody SignupRequestDto requestDto) {
         if (requestDto.getIsManager()) log.info("true");
         if (!requestDto.getIsManager()) log.info("false");
         userService.signUp(requestDto);
-        return ResponseEntity.ok()
-                .contentType(org.springframework.http.MediaType.APPLICATION_JSON)
+        return ResponseEntity.status(HttpStatus.CREATED)
                 .body("회원가입 성공!");
     }
 
     @PostMapping("/users/logout")
     public ResponseEntity<String> logout(HttpServletRequest request,
-                                         @AuthenticationPrincipal UserDetailsImpl userDetails) throws Exception {
+                                         @AuthenticationPrincipal UserDetailsImpl userDetails) {
         userService.logout(request, userDetails.getUser());
-        return ResponseEntity.status(HttpStatus.OK)
+        return ResponseEntity.status(HttpStatus.CREATED)
                 .body(userDetails.getUser() + " 아이디가 로그아웃 되었습니다.");
     }
 }

--- a/src/main/java/com/sparta/kanbanboardproject/domain/user/controller/UserController.java
+++ b/src/main/java/com/sparta/kanbanboardproject/domain/user/controller/UserController.java
@@ -1,4 +1,42 @@
 package com.sparta.kanbanboardproject.domain.user.controller;
 
+import com.sparta.kanbanboardproject.domain.user.dto.SignupRequestDto;
+import com.sparta.kanbanboardproject.domain.user.service.UserService;
+import com.sparta.kanbanboardproject.global.security.UserDetailsImpl;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RestController;
+
+@Slf4j(topic = "UserController")
+@RestController
+@RequiredArgsConstructor
 public class UserController {
+
+    private final UserService userService;
+
+    @PostMapping("/users/signup")
+    public ResponseEntity<String> signUp(
+            @Valid @RequestBody SignupRequestDto requestDto) {
+        if (requestDto.getIsManager()) log.info("true");
+        if (!requestDto.getIsManager()) log.info("false");
+        userService.signUp(requestDto);
+        return ResponseEntity.ok()
+                .contentType(org.springframework.http.MediaType.APPLICATION_JSON)
+                .body("회원가입 성공!");
+    }
+
+    @PostMapping("/users/logout")
+    public ResponseEntity<String> logout(HttpServletRequest request,
+                                         @AuthenticationPrincipal UserDetailsImpl userDetails) throws Exception {
+        userService.logout(request, userDetails.getUser());
+        return ResponseEntity.status(HttpStatus.OK)
+                .body(userDetails.getUser() + " 아이디가 로그아웃 되었습니다.");
+    }
 }

--- a/src/main/java/com/sparta/kanbanboardproject/domain/user/controller/UserController.java
+++ b/src/main/java/com/sparta/kanbanboardproject/domain/user/controller/UserController.java
@@ -23,17 +23,20 @@ public class UserController {
 
     @PostMapping("/users/signup")
     public ResponseEntity<String> signUp(@Valid @RequestBody SignupRequestDto requestDto) {
-        if (requestDto.getIsManager()) log.info("true");
-        if (!requestDto.getIsManager()) log.info("false");
+
         userService.signUp(requestDto);
+
         return ResponseEntity.status(HttpStatus.CREATED)
                 .body("회원가입 성공!");
     }
 
     @PostMapping("/users/logout")
-    public ResponseEntity<String> logout(HttpServletRequest request,
-                                         @AuthenticationPrincipal UserDetailsImpl userDetails) {
+    public ResponseEntity<String> logout(
+            HttpServletRequest request,
+            @AuthenticationPrincipal UserDetailsImpl userDetails) {
+
         userService.logout(request, userDetails.getUser());
+
         return ResponseEntity.status(HttpStatus.CREATED)
                 .body(userDetails.getUser() + " 아이디가 로그아웃 되었습니다.");
     }

--- a/src/main/java/com/sparta/kanbanboardproject/domain/user/dto/LoginRequestDto.java
+++ b/src/main/java/com/sparta/kanbanboardproject/domain/user/dto/LoginRequestDto.java
@@ -1,0 +1,16 @@
+package com.sparta.kanbanboardproject.domain.user.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+import lombok.Getter;
+
+@Getter
+public class LoginRequestDto {
+    @NotBlank
+    @Size(min = 3, max = 20, message = "username 은 3 ~ 15 글자 이내만 입력 가능합니다.")
+    private String username;
+
+    @NotBlank
+    @Size(min = 5, max = 20, message = "password 은 5 ~ 20 글자 이내만 입력 가능합니다.")
+    private String password;
+}

--- a/src/main/java/com/sparta/kanbanboardproject/domain/user/dto/SignupRequestDto.java
+++ b/src/main/java/com/sparta/kanbanboardproject/domain/user/dto/SignupRequestDto.java
@@ -1,4 +1,20 @@
 package com.sparta.kanbanboardproject.domain.user.dto;
 
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+import lombok.Data;
+
+@Data
 public class SignupRequestDto {
+    @NotBlank
+    @Size(min = 3, max = 15, message = "username 은 3 ~ 15 글자 이내만 입력 가능합니다.")
+    private String username;
+
+    @NotBlank
+    @Size(min = 5, max = 20, message = "password 은 5 ~ 20 글자 이내만 입력 가능합니다.")
+    private String password;
+
+    private Boolean isManager = false;
+
+    private String managerToken;
 }

--- a/src/main/java/com/sparta/kanbanboardproject/domain/user/entity/User.java
+++ b/src/main/java/com/sparta/kanbanboardproject/domain/user/entity/User.java
@@ -1,4 +1,43 @@
 package com.sparta.kanbanboardproject.domain.user.entity;
 
+import jakarta.persistence.*;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+@Entity
+@Getter
+@EntityListeners(AuditingEntityListener.class)
+@Table(name = "users")
+@NoArgsConstructor
 public class User {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(unique = true, nullable = false)
+    private String username;
+
+    @Column(nullable = false)
+    private String password;
+
+    @Column(nullable = false)
+    @Enumerated(EnumType.STRING)
+    private UserRoleEnum role;
+
+    @Setter
+    @Column(name = "refresh_token")
+    private String refreshToken;
+
+    public User(String username, String password, UserRoleEnum role) {
+        this.username = username;
+        this.password = password;
+        this.role = role;
+    }
+
+    public void logoutUser() {
+        refreshToken = "logged out";
+    }
 }

--- a/src/main/java/com/sparta/kanbanboardproject/domain/user/entity/UserRoleEnum.java
+++ b/src/main/java/com/sparta/kanbanboardproject/domain/user/entity/UserRoleEnum.java
@@ -1,0 +1,21 @@
+package com.sparta.kanbanboardproject.domain.user.entity;
+
+public enum UserRoleEnum {
+    USER(Authority.USER),  // 사용자 권한
+    MANAGER(Authority.MANAGER);  // 매니저 권한
+
+    private final String authority;
+
+    UserRoleEnum(String authority) {
+        this.authority = authority;
+    }
+
+    public String getAuthority() {
+        return this.authority;
+    }
+
+    public static class Authority {
+        public static final String USER = "ROLE_USER";
+        public static final String MANAGER = "ROLE_MANAGER";
+    }
+}

--- a/src/main/java/com/sparta/kanbanboardproject/domain/user/repository/UserRepository.java
+++ b/src/main/java/com/sparta/kanbanboardproject/domain/user/repository/UserRepository.java
@@ -7,4 +7,6 @@ import java.util.Optional;
 
 public interface UserRepository extends JpaRepository<User, Long> {
     Optional<User> findByUsername(String username);
+
+    Optional<User> findByRefreshToken(String refreshToken);
 }

--- a/src/main/java/com/sparta/kanbanboardproject/domain/user/repository/UserRepository.java
+++ b/src/main/java/com/sparta/kanbanboardproject/domain/user/repository/UserRepository.java
@@ -1,4 +1,10 @@
 package com.sparta.kanbanboardproject.domain.user.repository;
 
-public interface UserRepository {
+import com.sparta.kanbanboardproject.domain.user.entity.User;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface UserRepository extends JpaRepository<User, Long> {
+    Optional<User> findByUsername(String username);
 }

--- a/src/main/java/com/sparta/kanbanboardproject/domain/user/repository/UserRepositoryQuery.java
+++ b/src/main/java/com/sparta/kanbanboardproject/domain/user/repository/UserRepositoryQuery.java
@@ -1,0 +1,9 @@
+package com.sparta.kanbanboardproject.domain.user.repository;
+
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
+public class UserRepositoryQuery {
+    private final JPAQueryFactory jpaQueryFactory;
+}

--- a/src/main/java/com/sparta/kanbanboardproject/domain/user/service/UserService.java
+++ b/src/main/java/com/sparta/kanbanboardproject/domain/user/service/UserService.java
@@ -1,4 +1,56 @@
 package com.sparta.kanbanboardproject.domain.user.service;
 
+import com.sparta.kanbanboardproject.domain.user.dto.SignupRequestDto;
+import com.sparta.kanbanboardproject.domain.user.entity.User;
+import com.sparta.kanbanboardproject.domain.user.entity.UserRoleEnum;
+import com.sparta.kanbanboardproject.domain.user.repository.UserRepository;
+import com.sparta.kanbanboardproject.global.jwt.JwtService;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.transaction.Transactional;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+@Slf4j(topic = "UserService")
 public class UserService {
+
+    private final UserRepository userRepository;
+    private final JwtService jwtService;
+    private final PasswordEncoder passwordEncoder;
+
+    @Value("${manager.key}")
+    private String MANAGER_KEY;
+
+    public void signUp(SignupRequestDto requestDto) {
+        UserRoleEnum role = UserRoleEnum.USER;
+        if (requestDto.getIsManager()){
+            log.info("isManager true");
+            if (MANAGER_KEY.equals(requestDto.getManagerToken())){
+                log.info("managerKey equals");
+                role = UserRoleEnum.MANAGER;
+            }
+        }
+        User user = new User(requestDto.getUsername(), passwordEncoder.encode(requestDto.getPassword()), role);
+        userRepository.save(user);
+        log.info("회원가입 완료");
+    }
+
+    @Transactional
+    public void logout(HttpServletRequest request, User user) {
+        String accessToken = request.getHeader("Authorization").substring(7);
+
+        // 1. Access Token 검증
+        jwtService.validateToken(accessToken);
+
+        User saveUser = userRepository.findByUsername(user.getUsername()).orElseThrow(
+                ()-> new IllegalArgumentException("유저를 찾을 수 없습니다.")
+        );
+        saveUser.logoutUser();
+
+        log.info("로그아웃 성공");
+    }
 }

--- a/src/main/java/com/sparta/kanbanboardproject/domain/user/service/UserService.java
+++ b/src/main/java/com/sparta/kanbanboardproject/domain/user/service/UserService.java
@@ -27,9 +27,9 @@ public class UserService {
 
     public void signUp(SignupRequestDto requestDto) {
         UserRoleEnum role = UserRoleEnum.USER;
-        if (requestDto.getIsManager()){
+        if (requestDto.getIsManager()) {
             log.info("isManager true");
-            if (MANAGER_KEY.equals(requestDto.getManagerToken())){
+            if (MANAGER_KEY.equals(requestDto.getManagerToken())) {
                 log.info("managerKey equals");
                 role = UserRoleEnum.MANAGER;
             }

--- a/src/main/java/com/sparta/kanbanboardproject/domain/user/service/UserService.java
+++ b/src/main/java/com/sparta/kanbanboardproject/domain/user/service/UserService.java
@@ -43,7 +43,6 @@ public class UserService {
     public void logout(HttpServletRequest request, User user) {
         String accessToken = request.getHeader("Authorization").substring(7);
 
-        // 1. Access Token 검증
         jwtService.validateToken(accessToken);
 
         User saveUser = userRepository.findByUsername(user.getUsername()).orElseThrow(

--- a/src/main/java/com/sparta/kanbanboardproject/global/config/JPAConfiguration.java
+++ b/src/main/java/com/sparta/kanbanboardproject/global/config/JPAConfiguration.java
@@ -1,0 +1,21 @@
+package com.sparta.kanbanboardproject.global.config;
+
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.PersistenceContext;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
+
+@Configuration // 아래 설정을 등록하여 활성화 합니다.
+@EnableJpaAuditing // 시간 자동 변경이 가능하도록 합니다.
+public class JPAConfiguration {
+
+    @PersistenceContext
+    private EntityManager entityManager;
+
+    @Bean
+    public JPAQueryFactory jpaQueryFactory(){
+        return new JPAQueryFactory(entityManager);
+    }
+}

--- a/src/main/java/com/sparta/kanbanboardproject/global/config/JPAConfiguration.java
+++ b/src/main/java/com/sparta/kanbanboardproject/global/config/JPAConfiguration.java
@@ -15,7 +15,7 @@ public class JPAConfiguration {
     private EntityManager entityManager;
 
     @Bean
-    public JPAQueryFactory jpaQueryFactory(){
+    public JPAQueryFactory jpaQueryFactory() {
         return new JPAQueryFactory(entityManager);
     }
 }

--- a/src/main/java/com/sparta/kanbanboardproject/global/config/PasswordConfig.java
+++ b/src/main/java/com/sparta/kanbanboardproject/global/config/PasswordConfig.java
@@ -1,0 +1,15 @@
+package com.sparta.kanbanboardproject.global.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.security.crypto.password.PasswordEncoder;
+
+@Configuration
+public class PasswordConfig {
+
+    @Bean
+    public PasswordEncoder passwordEncoder() {
+        return new BCryptPasswordEncoder();
+    }
+}

--- a/src/main/java/com/sparta/kanbanboardproject/global/config/WebSecurityConfig.java
+++ b/src/main/java/com/sparta/kanbanboardproject/global/config/WebSecurityConfig.java
@@ -1,4 +1,86 @@
 package com.sparta.kanbanboardproject.global.config;
 
+import com.sparta.kanbanboardproject.domain.user.repository.UserRepository;
+import com.sparta.kanbanboardproject.global.jwt.JwtService;
+import com.sparta.kanbanboardproject.global.security.JwtAuthenticationFilter;
+import com.sparta.kanbanboardproject.global.security.JwtAuthorizationFilter;
+import com.sparta.kanbanboardproject.global.security.UserDetailsServiceImpl;
+import org.springframework.boot.autoconfigure.security.servlet.PathRequest;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.authentication.AuthenticationManager;
+import org.springframework.security.config.annotation.authentication.configuration.AuthenticationConfiguration;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.config.http.SessionCreationPolicy;
+import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
+
+@Configuration
+@EnableWebSecurity // Spring Security 지원을 가능하게 함
 public class WebSecurityConfig {
+
+    private final JwtService jwtService;
+    private final UserDetailsServiceImpl userDetailsService;
+    private final AuthenticationConfiguration authenticationConfiguration;
+    private final UserRepository userRepository;
+
+    public WebSecurityConfig(JwtService jwtService, UserDetailsServiceImpl userDetailsService,
+                             AuthenticationConfiguration authenticationConfiguration,
+                             UserRepository userRepository) {
+        this.jwtService = jwtService;
+        this.userDetailsService = userDetailsService;
+        this.authenticationConfiguration = authenticationConfiguration;
+        this.userRepository = userRepository;
+    }
+
+    @Bean
+    public AuthenticationManager authenticationManager(AuthenticationConfiguration configuration)
+            throws Exception {
+        return configuration.getAuthenticationManager();
+    }
+
+    @Bean
+    public JwtAuthenticationFilter jwtAuthenticationFilter() throws Exception {
+        JwtAuthenticationFilter filter = new JwtAuthenticationFilter(jwtService, userRepository);
+        filter.setAuthenticationManager(authenticationManager(authenticationConfiguration));
+        return filter;
+    }
+
+    @Bean
+    public JwtAuthorizationFilter jwtAuthorizationFilter() {
+        return new JwtAuthorizationFilter(jwtService, userDetailsService);
+    }
+
+    @Bean
+    public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
+        // CSRF 설정
+        http.csrf((csrf) -> csrf.disable());
+
+        // 기본 설정인 Session 방식은 사용하지 않고 JWT 방식을 사용하기 위한 설정
+        http.sessionManagement((sessionManagement) ->
+                sessionManagement.sessionCreationPolicy(SessionCreationPolicy.STATELESS)
+        );
+
+        http.authorizeHttpRequests((authorizeHttpRequests) ->
+                authorizeHttpRequests
+                        .requestMatchers(PathRequest.toStaticResources().atCommonLocations())
+                        .permitAll()
+                        .requestMatchers("/users/signup").permitAll()
+                        .requestMatchers("/users/login").permitAll()
+                        .requestMatchers("/auth/refresh-token").permitAll()
+                        .requestMatchers("/error").permitAll()
+                        .anyRequest().authenticated()
+        );
+
+//        http.exceptionHandling(auth -> {
+//            auth.authenticationEntryPoint(new CustomAuthenticationEntryPoint());
+//        });
+
+        // 필터 관리
+        http.addFilterBefore(jwtAuthorizationFilter(), JwtAuthenticationFilter.class);
+        http.addFilterBefore(jwtAuthenticationFilter(), UsernamePasswordAuthenticationFilter.class);
+
+        return http.build();
+    }
 }

--- a/src/main/java/com/sparta/kanbanboardproject/global/dto/HttpResponseDto.java
+++ b/src/main/java/com/sparta/kanbanboardproject/global/dto/HttpResponseDto.java
@@ -1,4 +1,0 @@
-package com.sparta.kanbanboardproject.global.dto;
-
-public class HttpResponseDto {
-}

--- a/src/main/java/com/sparta/kanbanboardproject/global/jwt/JwtService.java
+++ b/src/main/java/com/sparta/kanbanboardproject/global/jwt/JwtService.java
@@ -1,4 +1,158 @@
 package com.sparta.kanbanboardproject.global.jwt;
 
+import com.sparta.kanbanboardproject.domain.user.entity.User;
+import com.sparta.kanbanboardproject.domain.user.repository.UserRepository;
+import com.sparta.kanbanboardproject.global.security.UserDetailsServiceImpl;
+import io.jsonwebtoken.*;
+import io.jsonwebtoken.security.Keys;
+import jakarta.annotation.PostConstruct;
+import jakarta.servlet.http.HttpServletRequest;
+import lombok.RequiredArgsConstructor;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.stereotype.Component;
+import org.springframework.util.StringUtils;
+
+import java.security.Key;
+import java.util.Base64;
+import java.util.Date;
+import java.util.function.Function;
+
+@Component
+@RequiredArgsConstructor
 public class JwtService {
+
+    // 로그 설정
+    public static final Logger logger = LoggerFactory.getLogger("JWT 관련 로그");
+
+    private final UserDetailsServiceImpl userDetailsService;
+    private final UserRepository userRepository;
+
+    public static final String AUTHORIZATION_HEADER = "Authorization";
+    public static final String BEARER_PREFIX = "Bearer ";
+    private final long TOKEN_TIME = 30 * 60 * 1000L; // 30분
+    private final long REFRESH_TOKEN_TIME = 14 * 24 * 60 * 60 * 1000L; // 2주
+
+    @Value("${jwt.secret.key}")
+    private String secretKey;
+
+    private Key key;
+
+    private final SignatureAlgorithm signatureAlgorithm = SignatureAlgorithm.HS256;
+
+    @PostConstruct
+    public void init() {
+        byte[] bytes = Base64.getDecoder().decode(secretKey);
+        key = Keys.hmacShaKeyFor(bytes);
+    }
+
+    public String createToken(String userId) {
+        Date date = new Date();
+
+        return BEARER_PREFIX +
+                Jwts.builder()
+                        .setSubject(userId)
+                        .setExpiration(new Date(date.getTime() + TOKEN_TIME))
+                        .setIssuedAt(date)
+                        .signWith(signatureAlgorithm, key)
+                        .compact();
+    }
+
+    public String createRefreshToken(String userId) {
+        Date date = new Date();
+
+        return BEARER_PREFIX +
+                Jwts.builder()
+                        .setSubject(userId)
+                        .setExpiration(new Date(date.getTime() + REFRESH_TOKEN_TIME))
+                        .setIssuedAt(date)
+                        .signWith(signatureAlgorithm, key)
+                        .compact();
+    }
+
+    // JWT 토큰 substring
+    public String substringToken(String tokenValue) {
+        if (StringUtils.hasText(tokenValue) && tokenValue.startsWith(BEARER_PREFIX)) {
+            return tokenValue.substring(7);
+        }
+        logger.error("Not Found Token");
+        throw new NullPointerException("Not Found Token");
+    }
+
+    // 토큰 검증
+    public boolean validateToken(String token) {
+        try {
+            Jwts.parserBuilder().setSigningKey(key).build().parseClaimsJws(token);
+
+            String username = extractUsername(token);
+            User user = userRepository.findByUsername(username)
+                    .orElseThrow(IllegalArgumentException::new);
+
+            if ("logged out".equals(user.getRefreshToken())) {
+                logger.error("로그아웃된 유저의 Refresh Token입니다.");
+                return false;
+            }
+            return true;
+        } catch (SecurityException | MalformedJwtException | SignatureException e) {
+            logger.error("Invalid JWT signature, 유효하지 않는 JWT 서명 입니다.");
+        } catch (ExpiredJwtException e) {
+            logger.error("Expired JWT token, 만료된 JWT token 입니다.");
+        } catch (UnsupportedJwtException e) {
+            logger.error("Unsupported JWT token, 지원되지 않는 JWT 토큰 입니다.");
+        } catch (IllegalArgumentException e) {
+            logger.error("JWT claims is empty, 잘못된 JWT 토큰 입니다.");
+        }
+        return false;
+    }
+
+    // 토큰에서 사용자 정보 가져오기
+    public Claims getUserInfoFromToken(String token) {
+        return Jwts.parserBuilder().setSigningKey(key).build().parseClaimsJws(token).getBody();
+    }
+
+    //Token 으로 Authentication 가져오기
+    public Authentication getAuthentication(String token) {
+        String username = extractUsername(token);
+        UserDetails userDetails = userDetailsService.loadUserByUsername(username);
+        return new UsernamePasswordAuthenticationToken(userDetails, "",
+                userDetails.getAuthorities());
+    }
+
+    // HttpServletRequest 에서 access token 가져오기
+    public String getTokenFromRequest(HttpServletRequest req) {
+        String accessToken = req.getHeader("Authorization").substring(7);
+
+        return accessToken;
+    }
+
+    public String extractUsername(String token) {
+        return extractClaim(token, Claims::getSubject);
+    }
+
+    private <T> T extractClaim(String token, Function<Claims, T> claimsResolver) {
+        final Claims claims = extractAllClaims(token);
+        return claimsResolver.apply(claims);
+    }
+
+    private Claims extractAllClaims(String token) {
+        return Jwts.parser().setSigningKey(key).parseClaimsJws(token).getBody();
+    }
+
+    public Date extractExpiration(String token) {
+        return extractAllClaims(token).getExpiration();
+    }
+
+    public long getRemainingValidityMillis(String accessToken) {
+        Date expiration = extractExpiration(accessToken);
+        Date now = new Date();
+        return expiration.getTime() - now.getTime();
+    }
+
+    public boolean isTokenExpired(String token) {
+        return extractExpiration(token).before(new Date());
+    }
 }

--- a/src/main/java/com/sparta/kanbanboardproject/global/jwt/JwtService.java
+++ b/src/main/java/com/sparta/kanbanboardproject/global/jwt/JwtService.java
@@ -114,7 +114,7 @@ public class JwtService {
         return Jwts.parserBuilder().setSigningKey(key).build().parseClaimsJws(token).getBody();
     }
 
-    //Token 으로 Authentication 가져오기
+    // Token 으로 Authentication 가져오기
     public Authentication getAuthentication(String token) {
         String username = extractUsername(token);
         UserDetails userDetails = userDetailsService.loadUserByUsername(username);

--- a/src/main/java/com/sparta/kanbanboardproject/global/jwt/JwtService.java
+++ b/src/main/java/com/sparta/kanbanboardproject/global/jwt/JwtService.java
@@ -50,24 +50,24 @@ public class JwtService {
         key = Keys.hmacShaKeyFor(bytes);
     }
 
-    public String createToken(String userId) {
+    public String createToken(String username) {
         Date date = new Date();
 
         return BEARER_PREFIX +
                 Jwts.builder()
-                        .setSubject(userId)
+                        .setSubject(username)
                         .setExpiration(new Date(date.getTime() + TOKEN_TIME))
                         .setIssuedAt(date)
                         .signWith(signatureAlgorithm, key)
                         .compact();
     }
 
-    public String createRefreshToken(String userId) {
+    public String createRefreshToken(String username) {
         Date date = new Date();
 
         return BEARER_PREFIX +
                 Jwts.builder()
-                        .setSubject(userId)
+                        .setSubject(username)
                         .setExpiration(new Date(date.getTime() + REFRESH_TOKEN_TIME))
                         .setIssuedAt(date)
                         .signWith(signatureAlgorithm, key)

--- a/src/main/java/com/sparta/kanbanboardproject/global/security/JwtAuthenticationFilter.java
+++ b/src/main/java/com/sparta/kanbanboardproject/global/security/JwtAuthenticationFilter.java
@@ -1,4 +1,80 @@
 package com.sparta.kanbanboardproject.global.security;
 
-public class JwtAuthenticationFilter {
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.sparta.kanbanboardproject.domain.user.dto.LoginRequestDto;
+import com.sparta.kanbanboardproject.domain.user.entity.User;
+import com.sparta.kanbanboardproject.domain.user.repository.UserRepository;
+import com.sparta.kanbanboardproject.global.jwt.JwtService;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
+
+import java.io.IOException;
+
+@Slf4j(topic = "로그인 및 JWT 생성")
+public class JwtAuthenticationFilter extends UsernamePasswordAuthenticationFilter {
+    private final JwtService jwtService;
+    private final UserRepository userRepository;
+
+    public JwtAuthenticationFilter(JwtService jwtService, UserRepository userRepository) {
+        this.jwtService = jwtService;
+        this.userRepository = userRepository;
+        setFilterProcessesUrl("/users/login");
+    }
+
+    @Override
+    public Authentication attemptAuthentication(HttpServletRequest request, HttpServletResponse response) throws AuthenticationException {
+        log.info("로그인 시도");
+        try{
+            LoginRequestDto loginRequestDto = new ObjectMapper().readValue(request.getInputStream(), LoginRequestDto.class);
+
+            User user = userRepository.findByUsername(loginRequestDto.getUsername()).orElseThrow(NullPointerException::new);
+
+            return getAuthenticationManager().authenticate(
+                    new UsernamePasswordAuthenticationToken(
+                            loginRequestDto.getUsername(),
+                            loginRequestDto.getPassword(),
+                            null
+
+                    )
+            );
+        } catch (IOException e) {
+            log.error(e.getMessage());
+            throw new RuntimeException(e.getMessage());
+        }
+    }
+
+    @Override
+    protected void successfulAuthentication(HttpServletRequest request, HttpServletResponse response, FilterChain chain, Authentication authResult) throws IOException, ServletException {
+        log.info("로그인 성공 및 JWT 생성");
+        String username = ((UserDetailsImpl) authResult.getPrincipal()).getUsername();
+
+        // 토큰 생성
+        String token = jwtService.createToken(username);
+        String refreshToken = jwtService.createRefreshToken(username);
+        // refresh token 유저에 저장
+        User user = userRepository.findByUsername(username).orElseThrow(NullPointerException::new);
+        user.setRefreshToken(refreshToken);
+
+        userRepository.save(user);
+
+        // 헤더에 토큰 저장
+        response.setHeader("Authorization", token);
+        response.setHeader("RefreshToken", refreshToken);
+        // 로그인 성공 메세지 반환
+        response.setCharacterEncoding("UTF-8");
+        response.getWriter().write(new ObjectMapper().writeValueAsString("로그인 성공!"));
+    }
+
+    @Override
+    protected void unsuccessfulAuthentication(HttpServletRequest request, HttpServletResponse response, AuthenticationException failed) throws IOException, ServletException {
+        log.info("로그인 실패");
+        response.setStatus(401);
+    }
 }

--- a/src/main/java/com/sparta/kanbanboardproject/global/security/JwtAuthorizationFilter.java
+++ b/src/main/java/com/sparta/kanbanboardproject/global/security/JwtAuthorizationFilter.java
@@ -1,0 +1,70 @@
+package com.sparta.kanbanboardproject.global.security;
+
+import com.sparta.kanbanboardproject.global.jwt.JwtService;
+import io.jsonwebtoken.Claims;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContext;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.util.StringUtils;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import java.io.IOException;
+
+@Slf4j(topic = "JWT 검증 및 인가")
+@RequiredArgsConstructor
+public class JwtAuthorizationFilter extends OncePerRequestFilter {
+
+    private final JwtService jwtService;
+    private final UserDetailsServiceImpl userDetailsService;
+
+    @Override
+    protected void doFilterInternal(HttpServletRequest req, HttpServletResponse res, FilterChain filterChain) throws ServletException, IOException {
+
+        String tokenValue = req.getHeader("Authorization");
+
+        if (StringUtils.hasText(tokenValue)) {
+            // JWT 토큰 substring
+            tokenValue = jwtService.substringToken(tokenValue);
+            log.info(tokenValue);
+
+            if (!jwtService.validateToken(tokenValue)) {
+                log.error("Token Error");
+                return;
+            }
+
+            Claims info = jwtService.getUserInfoFromToken(tokenValue);
+
+            try {
+                setAuthentication(info.getSubject());
+            } catch (Exception e) {
+                log.error(e.getMessage());
+                return;
+            }
+        }
+
+        filterChain.doFilter(req, res);
+    }
+
+    // 인증 처리
+    public void setAuthentication(String username) {
+        SecurityContext context = SecurityContextHolder.createEmptyContext();
+        Authentication authentication = createAuthentication(username);
+        context.setAuthentication(authentication);
+
+        SecurityContextHolder.setContext(context);
+    }
+
+    // 인증 객체 생성
+    private Authentication createAuthentication(String username) {
+        UserDetails userDetails = userDetailsService.loadUserByUsername(username);
+        return new UsernamePasswordAuthenticationToken(userDetails, null, userDetails.getAuthorities());
+    }
+}

--- a/src/main/java/com/sparta/kanbanboardproject/global/security/UserDetailsImpl.java
+++ b/src/main/java/com/sparta/kanbanboardproject/global/security/UserDetailsImpl.java
@@ -10,7 +10,6 @@ import org.springframework.security.core.userdetails.UserDetails;
 import java.util.ArrayList;
 import java.util.Collection;
 
-
 @Slf4j
 public class UserDetailsImpl implements UserDetails {
 

--- a/src/main/java/com/sparta/kanbanboardproject/global/security/UserDetailsImpl.java
+++ b/src/main/java/com/sparta/kanbanboardproject/global/security/UserDetailsImpl.java
@@ -1,0 +1,68 @@
+package com.sparta.kanbanboardproject.global.security;
+
+import com.sparta.kanbanboardproject.domain.user.entity.User;
+import com.sparta.kanbanboardproject.domain.user.entity.UserRoleEnum;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.userdetails.UserDetails;
+
+import java.util.ArrayList;
+import java.util.Collection;
+
+
+@Slf4j
+public class UserDetailsImpl implements UserDetails {
+
+    private final User user;
+
+    public UserDetailsImpl(User user) {
+        this.user = user;
+    }
+
+    public User getUser() {
+        return user;
+    }
+
+    @Override
+    public String getPassword() {
+        return user.getPassword();
+    }
+
+    @Override
+    public String getUsername() {
+        return user.getUsername();
+    }
+
+    @Override
+    public Collection<? extends GrantedAuthority> getAuthorities() {
+        UserRoleEnum role = user.getRole();
+        String authority = role.getAuthority();
+
+        SimpleGrantedAuthority simpleGrantedAuthority = new SimpleGrantedAuthority(authority);
+        Collection<GrantedAuthority> authorities = new ArrayList<>();
+        authorities.add(simpleGrantedAuthority);
+
+        return authorities;
+    }
+
+    @Override
+    public boolean isAccountNonExpired() {
+        return true;
+    }
+
+    @Override
+    public boolean isAccountNonLocked() {
+        return true;
+    }
+
+    @Override
+    public boolean isCredentialsNonExpired() {
+        return true;
+    }
+
+    @Override
+    public boolean isEnabled() {
+        return true;
+    }
+}

--- a/src/main/java/com/sparta/kanbanboardproject/global/security/UserDetailsServiceImpl.java
+++ b/src/main/java/com/sparta/kanbanboardproject/global/security/UserDetailsServiceImpl.java
@@ -1,0 +1,24 @@
+package com.sparta.kanbanboardproject.global.security;
+
+import com.sparta.kanbanboardproject.domain.user.entity.User;
+import com.sparta.kanbanboardproject.domain.user.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.core.userdetails.UserDetailsService;
+import org.springframework.security.core.userdetails.UsernameNotFoundException;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class UserDetailsServiceImpl implements UserDetailsService {
+
+    private final UserRepository userRepository;
+
+    @Override
+    public UserDetails loadUserByUsername(String username) throws UsernameNotFoundException {
+        User user = userRepository.findByUsername(username)
+                .orElseThrow(() -> new UsernameNotFoundException("Not Found " + username));
+
+        return new UserDetailsImpl(user);
+    }
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -22,3 +22,10 @@ spring:
           characterEncoding: utf-8
           useUnicode: true
     show-sql: true
+
+manager:
+  key: ${MANAGER_KEY}
+
+jwt:
+  secret:
+    key: ${JWT_SECRET_KEY}


### PR DESCRIPTION
## #️⃣연관된 이슈

>#1  
>#2 
>#3  
>#4  
>#5 

## 📝작업 내용

> 1. user entity add
>
> 2. signup feature -> 매니저, 유저 두 개의 권한으로 회원가입 가능
>
> 3. login feature 
>
> 4. logout feature -> 로그아웃 시 User field에 refreshToken 값이 "logged out" 으로 변경
>
> 5. refresh-token reissue feature -> refresh-token을 가지고 재발급 요청 시 현재 유저가 갖고있는 refresh-tokne과 같은 지, 또는 토큰 자체의 유효성 검사를 마치고 통과 시 access와 refresh token을 둘 다 재발급해서 response의 header로 넣어서 보냄

## 예외 상황

> user entity에 @EntityListeners(AuditingEntityListener.class) annotation을 삭제해야함. -> auditing featrue를 사용하지 않음.
